### PR TITLE
fix(terraform): update name to region attribute for aws_region

### DIFF
--- a/examples/basic/base.tf
+++ b/examples/basic/base.tf
@@ -27,7 +27,7 @@ module "eks_cluster" {
   }
 
   name       = "eks"
-  region     = data.aws_region.this.id
+  region     = data.aws_region.this.region
   subnet_ids = module.vpc.public_subnets
 }
 


### PR DESCRIPTION
# Description

The `id` attribute of the `aws_region` data source is deprecated — the AWS
provider now exposes the region name through the dedicated `region` attribute.

This PR replaces every `data.aws_region.<name>[...].id` reference with
`.region` so the module no longer depends on the deprecated attribute and stays
compatible with current AWS provider versions.

This is a drop-in change: `region` returns the same value the deprecated `id`
attribute did, so no plan diff or behavioural change is expected.

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [x] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

- `terraform init` and `terraform providers lock` complete cleanly for the affected modules.
- Pre-commit hooks (`terraform_fmt`, `terraform_validate` / tflint, `terraform_docs`) pass.
- `region` is a documented drop-in replacement for the deprecated `id` attribute, so no configuration diff is expected.
